### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/fabric8-analytics-pgbouncer:latest
+FROM quay.io/openshiftio/rhel-base-fabric8-analytics-pgbouncer:latest
 
 COPY run-pgbouncer.sh health-check-probe.sh /usr/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
+REGISTRY := quay.io
+DEFAULT_TAG := latest
+
 ifeq ($(TARGET),rhel)
   DOCKERFILE := Dockerfile.rhel
-  REGISTRY := push.registry.devshift.net/osio-prod
+  REPOSITORY := rhel-bayesian-coreapi-pgbouncer
 else
   DOCKERFILE := Dockerfile
-  REGISTRY := push.registry.devshift.net
+  REPOSITORY := bayesian-coreapi-pgbouncer
 endif
-REPOSITORY?=bayesian/coreapi-pgbouncer
-DEFAULT_TAG=latest
 
 .PHONY: all docker-build fast-docker-build test get-image-name get-image-repository
 

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ DEFAULT_TAG := latest
 
 ifeq ($(TARGET),rhel)
   DOCKERFILE := Dockerfile.rhel
-  REPOSITORY := rhel-bayesian-coreapi-pgbouncer
+  REPOSITORY := openshiftio/rhel-bayesian-coreapi-pgbouncer
 else
   DOCKERFILE := Dockerfile
-  REPOSITORY := bayesian-coreapi-pgbouncer
+  REPOSITORY := openshiftio/bayesian-coreapi-pgbouncer
 endif
 
 .PHONY: all docker-build fast-docker-build test get-image-name get-image-repository

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,12 +1,8 @@
 #!/bin/bash -ex
 
 load_jenkins_vars() {
-    if [ -e "jenkins-env" ]; then
-        cat jenkins-env \
-          | grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-          | sed 's/^/export /g' \
-          > ~/.jenkins-env
-        source ~/.jenkins-env
+    if [ -e "jenkins-env.json" ]; then
+        eval "$(./env-toolkit load -f jenkins-env.json DEVSHIFT_TAG_LEN QUAY_USERNAME QUAY_PASSWORD ghprbPullId)"
     fi
 }
 
@@ -20,8 +16,8 @@ build_image() {
     local push_registry
     push_registry=$(make get-push-registry)
     # login before build to be able to pull RHEL parent image
-    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${push_registry}
+    if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+        docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} ${push_registry}
     else
         echo "Could not login, missing credentials for the registry"
         exit 1

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -107,7 +107,7 @@ parameters:
   displayName: Docker image
   required: true
   name: DOCKER_IMAGE
-  value: "rhel-bayesian-coreapi-pgbouncer"
+  value: "openshiftio/rhel-bayesian-coreapi-pgbouncer"
 
 - description: Image tag
   displayName: Image tag

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -101,16 +101,16 @@ parameters:
   displayName: Docker registry
   required: true
   name: DOCKER_REGISTRY
-  value: "registry.devshift.net"
+  value: "quay.io"
 
 - description: Docker image to use
   displayName: Docker image
   required: true
-  name: DOCKER_IMAGE 
-  value: "bayesian/coreapi-pgbouncer"
+  name: DOCKER_IMAGE
+  value: "rhel-bayesian-coreapi-pgbouncer"
 
 - description: Image tag
   displayName: Image tag
   required: true
-  name: IMAGE_TAG 
+  name: IMAGE_TAG
   value: "latest"  # image-tag


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.
https://github.com/openshiftio/saas-analytics/pull/410